### PR TITLE
Add a HTTP-Rest /filter/ endpoint 

### DIFF
--- a/apiUtils.lua
+++ b/apiUtils.lua
@@ -1,0 +1,33 @@
+local turbo = require 'turbo'
+
+local module = {}
+
+function module.checkForToken(requestHandler, allowedToken)
+  local token = requestHandler.request.headers:get("X-Authorization-Token", true)
+  if token ~= nil then
+      for _,v in pairs(allowedToken) do
+        if v == token then
+          return true
+        end
+      end
+  end
+  return false
+end
+
+function module.ifAuthorized(requestHandler, allowedToken, fct)
+  -- check for the X-Authorization-Token header and compare its value to the ones present in allowedToken
+  if module.checkForToken(requestHandler, allowedToken) then
+    fct()
+  else
+    error(turbo.web.HTTPError(401, {message = "Unauthorized."}))
+  end
+end
+
+function module.checkFilterAttributes (filterObject)
+  local requiredKeys = filterObject['id'] ~= nil and filterObject['filter'] ~= nil
+  -- pipes present => it should be an array of numbers (logical consequence)
+  local pipesCorrect = not (filterObject['pipes'] ~= nil) or (type(filterObject['pipes']) == 'table')
+  return requiredKeys and pipesCorrect
+end
+
+return module

--- a/flowscope.lua
+++ b/flowscope.lua
@@ -15,6 +15,8 @@ local pipe   = require "pipe"
 local timer  = require "timer"
 local flowtracker = require "flowtracker"
 local ev = require "event"
+local webServer = require "webserver"
+local restApi	= require "restApi"
 
 local jit = require "jit"
 jit.opt.start("maxrecord=10000", "maxirconst=1000", "loopunroll=40")
@@ -31,6 +33,10 @@ function configure(parser)
 	parser:option("--log-level", "Log level"):default("WARN"):target("logLevel")
 	parser:option("--max-rules", "Maximum number of rules"):convert(tonumber):default("100"):target("maxRules")
 	parser:flag("--generate", "Generate traffic instead of reading from a device"):default(False)
+	parser:option("-p --api-port", "Port for the HTTP REST api."):convert(tonumber):default("8000"):target("apiPort")
+	parser:option("-b --api-bind", "Bind to a specific IP address. (for example 127.0.0.1)"):target("apiAddress")
+	parser:option("-t --api-token", "Token for authorization to api."):default("hardToGuess"):target("apiToken"):count("*")
+
 	local args = parser:parse()
 	return args
 end
@@ -47,7 +53,7 @@ function master(args)
 		end
 		device.waitForLinks()
 	end
-	
+
 	local qq = qq.createQQ(args.size)
 	for i, dev in ipairs(args.dev) do
 		for i = 0, args.rxThreads - 1 do
@@ -58,28 +64,38 @@ function master(args)
 			end
 		end
 	end
-	
+
 	local pipes = {}
 	for i = 1, args.dumperThreads do
 		pipes[i] = pipe.newSlowPipe()
 		moon.startTask("continuousDumper", args, qq, i, args.path, pipes[i])
 	end
-	
+
 -- 	local tracker = flowtracker.createTBBMapv4(2^20)
 
 	local tracker = flowtracker.createTBBTracker(2^20)
 	moon.startTask("swapper", args, tracker, pipes)
-	
+
 	for i = 1, args.analyzeThreads do
 -- 		moon.startTask("dummyAnalyzer", qq, i)
 -- 		moon.startTask("TBBAnalyzer", qq, i, tracker, pipes)
 		moon.startTask("TBBTrackerAnalyzer", args, qq, i, tracker, pipes)
 	end
-	
+
+	-- start the webserver
+	if args.apiAddress ~= nil then
+		webServer.startWebserverTask(
+		{
+			port = args.apiPort,
+			bind = args.apiAddress,
+			init = 'initWebserverTask'
+		}, args, pipes)
+	end
+
 	for i, v in ipairs(pipes) do
 		-- libmoon has no destroy function for pipes
 	end
-	
+
 	moon.startSharedTask("fillLevelChecker", args, qq)
 	--moon.startTask("fillLevelChecker", args, qq)
 	moon.waitForTasks()
@@ -92,6 +108,10 @@ function inserter(rxQueue, qq)
 	-- the inserter is C++ in libqq to get microsecond-level software timestamping precision
 	qq:inserterLoop(rxQueue)
 	log:info("[Inserter]: Shutdown")
+end
+
+function initWebserverTask(turbo, args, pipes)
+	return restApi.start(turbo, args, pipes)
 end
 
 function swapper(args, tracker, pipes)
@@ -121,7 +141,7 @@ function traffic_generator(args, qq, id, packetSize, newFlowRate, rate)
 	local txCtr = stats:newManualTxCounter("Generator Thread #" .. id, "plain")
 	local rateLimiter = timer:new(1.0 / rate)
 	local newFlowTimer = timer:new(1.0 / newFlowRate)
-	
+
 	local buf = {}
 	buf["ptr"] = ffi.new("uint8_t[?]", packetSize)
 	buf["getData"] = function() return ffi.cast("void*", buf.ptr) end
@@ -134,7 +154,7 @@ function traffic_generator(args, qq, id, packetSize, newFlowRate, rate)
 	pkt.udp:setSrcPort(1000)
 	pkt.udp:setDstPort(2000)
 	pkt:dump()
-	
+
 	while moon.running() do
 		local s1 = qq:enqueue()
 		local ts = moon.getTime() * 10^6
@@ -199,9 +219,9 @@ function TBBTrackerAnalyzer(args, qq, id, hashmap, pipes)
 	local rxCtr = stats:newManualRxCounter("TBB Tracker Analyzer Thread #" .. id, "plain")
 	local epsilon = 2  -- allowed area around the avrg. TLL
 	local tuple = ffi.new("struct ipv4_5tuple")
-	
+
 	local acc = flowtracker.createAccessor()
-	
+
 	while moon.running() do
 		local storage = qq:tryPeek()
 		if storage == nil then
@@ -258,7 +278,7 @@ function TBBTrackerAnalyzer(args, qq, id, hashmap, pipes)
 -- 					tuple.port_src = parsedPkt.udp:getSrcPort()
 -- 					tuple.proto = parsedPkt.ip4:getProtocol()
 -- 				else
--- 					
+--
 -- 				end
 			end
 			-- Parsing ends
@@ -311,8 +331,7 @@ function continuousDumper(args, qq, id, path, filterPipe)
 	local maxRules = args.maxRules
 	local rxCtr = stats:newManualRxCounter("Dumper Thread   #" .. id, "plain")
 	local lastTS = 0
-	
-	require("jit.p").start("l2s")
+
 	while moon.running() do
 		-- Get new filters
 		-- TODO: loop until all messages are read
@@ -325,7 +344,7 @@ function continuousDumper(args, qq, id, path, filterPipe)
 				local pcapFileName = path .. ("/FlowScope-dump " .. os.date("%Y-%m-%d %H-%M-%S", triggerWallTime) .. " " .. event.filter .. " part " .. id .. ".pcap"):gsub(" ", "_")
 				local pcapWriter = pcap:newWriter(pcapFileName, triggerWallTime)
 				ruleSet[event.id] = {pfFn = pf.compile_filter(event.filter), pcap = pcapWriter}
-				--ruleSet[event.filter] = {pfFn = function() return false end, pcap = nil}
+				--ruleSet[event.filter] = {pfFn = function() end, pcap = nil}
 				needRebuild = true
 			elseif event.action == ev.delete and ruleSet[event.id] ~= nil then
 				ruleSet[event.id].timestamp = event.timestamp
@@ -349,28 +368,26 @@ function continuousDumper(args, qq, id, path, filterPipe)
 		if needRebuild then
 			ruleList = {}
 			for _, v in pairs(ruleSet) do
-				ruleList[#ruleList+1] = {v.pfFn, v.pcap}
+				ruleList[#ruleList+1] = v
 			end
 			log:info("Dumper #%i: total number of rules: %i", id, #ruleList)
 		end
+
 		local storage = qq:tryDequeue()
 		if storage == nil then
 			goto skip
 		end
-		rxCtr:updateWithSize(storage:size(), 0)
 		for i = 0, storage:size() - 1 do
 			local pkt = storage:getPacket(i)
 			local timestamp = pkt:getTimestamp()
-			local data = pkt.data
-			local len = pkt.len
 			lastTS = tonumber(pkt.ts_vlan)
-			-- Do not use ipairs() here
-			for j = 1, #ruleList do
-				local filter = ruleList[j][1]
-				local pcap = ruleList[j][2]
-				if filter(data, len) then
-					if pcap then
-						pcap:write(timestamp, data, len)
+			rxCtr:updateWithSize(1, pkt:getLength())
+
+			for _, rule in ipairs(ruleList) do
+				if rule.pfFn(pkt.data, pkt.len) then
+-- 					print("Dumper #" .. id .. ": Got match!")
+					if rule.pcap then
+						rule.pcap:write(timestamp, pkt.data, pkt.len)
 					end
 				end
 			end
@@ -378,7 +395,6 @@ function continuousDumper(args, qq, id, path, filterPipe)
 		storage:release()
 		::skip::
 	end
-	require("jit.p").stop()
 	rxCtr:finalize()
 	for _, rule in pairs(ruleSet) do
 		if rule.pcap then
@@ -389,4 +405,3 @@ function continuousDumper(args, qq, id, path, filterPipe)
 	end
 	log:info("[Dumper]: Shutdown")
 end
-

--- a/restApi.lua
+++ b/restApi.lua
@@ -1,0 +1,125 @@
+local apiUtils = require 'apiUtils'
+local event = require 'event'
+
+local mod = {}
+
+-- args need to contain: args.apiToken and api.dumperThreads and we need access to the pipes
+-- to interface the dumperThreads and apply new filters
+function mod.start(turbo, args, pipes)
+  -- this webhandler modifies specific filter (i.e given by an id)
+  local SpecificFilterWebHandler = class("SpecificFilterWebHandler", turbo.web.RequestHandler)
+  -- this Webhandler handles only creation of a filter and showing all (under the namespace /filter/)
+  local FilterWebHandler = class("FilterWebHandler", turbo.web.RequestHandler)
+
+  -- RegExes to check on the filter ids/paths
+  local FILTER_ID_REGEX = "([a-zA-Z0-9]+)"
+  local SPECIFIC_FILTER_REGEX = string.format("^/filter/%s$", FILTER_ID_REGEX)
+
+  local filters = { }
+
+  function SpecificFilterWebHandler:get()
+    local function showFilter()
+      local filterId = string.match(self.request.path, SPECIFIC_FILTER_REGEX)
+      if filters[filterId] ~= nil then
+        self:write(filters[filterId])
+        self:finish()
+      else
+        error(turbo.web.HTTPError(404, {error = "Not found"}))
+      end
+    end
+    apiUtils.ifAuthorized(self, args.apiToken, showFilter)
+  end
+
+  function SpecificFilterWebHandler:put()
+    error(turbo.web.HTTPError(501, {error = "Update not implemented."}))
+  end
+
+  function SpecificFilterWebHandler:delete()
+    local function deleteFilter()
+      local filterId = string.match(self.request.path, SPECIFIC_FILTER_REGEX)
+      if filters[filterId] ~= nil then
+        local filter = filters[filterId]
+        filters[filterId] = nil
+        filter.action = event.delete
+        -- Remove filter from flowscope
+        for i,_ in ipairs(filter.pipes) do
+          pipes[i]:send(event.newEvent(filter.filter, event.delete, filter.id, filter.timestamp))
+        end
+        self:write(filter)
+        self:finish()
+      else
+        error(turbo.web.HTTPError(404, {error = "Not found."}))
+      end
+    end
+    apiUtils.ifAuthorized(self, args.apiToken, deleteFilter)
+  end
+
+  function FilterWebHandler:post()
+    local function createFilter()
+      -- this will raise an error if json is not present
+      local jsonBody = self:get_json(true)
+      -- create the array of pipes where we want to apply the filter
+      local insertToPipes = {}
+
+      if jsonBody == nil or not apiUtils.checkFilterAttributes(jsonBody) then
+        error(turbo.web.HTTPError(400, {error = "Filter json malformed."}))
+      end
+      --  Test the filter id
+
+
+      for i = 1, args.dumperThreads do
+        insertToPipes[i] = i
+      end
+      local filter = {
+        id = tostring(jsonBody.id),
+        filter = jsonBody.filter,
+        timestamp = jsonBody.timestamp,
+        action = event.create,
+        pipes = {}
+      }
+      -- formatting of the pipes is already checked in apiUtils.checkFilterAttributes
+      if jsonBody['pipes'] ~= nil then
+        for i,pipe_number in ipairs(jsonBody['pipes']) do
+          if(insertToPipes[pipe_number] ~= nil) then
+            filter.pipes[i] = pipe_number
+          else
+            error(turbo.web.HTTPError(400, {error = "Pipe number " .. tostring(pipe_number) .. " not allowed."}))
+          end
+        end
+      else
+        filter.pipes = insertToPipes
+      end
+
+      if filters[filter.id] ~= nil then
+        error(turbo.web.HTTPError(400, {error = "Filter id is already in use. Choose another one."}))
+      else
+        filters[filter.id] = filter
+        -- add filter to pipe (what if pipe argument is not present? => add to all)
+        for i, pipe in ipairs(pipes) do
+          if insertToPipes[i] ~= nil then
+            pipe:send(event.newEvent(filter.filter, event.create, filter.id, filter.timestamp))
+          end
+        end
+        self:write(filter)
+        self:finish()
+      end
+    end
+
+    apiUtils.ifAuthorized(self, args.apiToken, createFilter)
+  end
+
+  function FilterWebHandler:get()
+    local function showFilters()
+      self:write(filters)
+      self:finish()
+    end
+    apiUtils.ifAuthorized(self, args.apiToken, showFilters)
+  end
+
+  return {
+    { SPECIFIC_FILTER_REGEX, SpecificFilterWebHandler},
+    { "^/filter/$", FilterWebHandler}
+  }
+end
+
+return mod


### PR DESCRIPTION
This pull-request adds a rest-api implementation with the help of the turbo-lua framework.
Post to /filter the following json to create a filter that captures all udp traffic between port 1000 and 10000:
```json
{
    "filter": "udp dst portrange 1000-10000",  -> the filter in pflang
    "id": "p1", -> the id of the filter (arbitrary string)
    "pipes": [1, 2], -> the dumper thread this filter should be applied to
    "timestamp": 1508018400 -> the timestamp the filter should expire on
}
```
Now you may want to know whats the bare minimum for this filter? - Right I got you covered:
```json
{
  "filter": "udp dst portrange 1000-10000",
  "id": "p1"
}
```
So the filter and id key are mandatory and the other two are optional.
Furthermore the api is secured via an access token passed as a http-header.
Assuming you stored one of the jsons above in the file ```create_filter.json```,
you can activate the filter with:
```shell
curl -X POST -d @create_filter.json http://localhost:8000/filter/ --header "X-Authorization-Token: hardToGuess" --header "Content-Type:application/json \n charset=utf8"
```
And delete it with
```shell
curl -X DELETE -d @create_filter.json http://localhost:8000/filter/1 --header "X-Authorization-Token: hardToGuess" --header "Content-Type:application/json \n charset=utf8"
```
And if you want to know which filter are active:
```shell
curl http://localhost:8000/filter/ --header "X-Authorization-Token: hardToGuess"
```

Unfortunately I couldn't figure out how to update the ```libmoon``` submodule to make this change work. - Never mind, I found a solution.