### PR TITLE
Add http pipelining

### DIFF
--- a/apiUtils.lua
+++ b/apiUtils.lua
@@ -1,33 +1,75 @@
 local turbo = require 'turbo'
+local event = require 'event'
 
 local module = {}
 
+module.filterIdRegex = "([a-zA-Z0-9.:-_]+)"
+
 function module.checkForToken(requestHandler, allowedToken)
-  local token = requestHandler.request.headers:get("X-Authorization-Token", true)
-  if token ~= nil then
-      for _,v in pairs(allowedToken) do
-        if v == token then
-          return true
+    local token = requestHandler.request.headers:get("X-Authorization-Token", true)
+    if token ~= nil then
+        for _, v in pairs(allowedToken) do
+            if v == token then
+                return true
+            end
         end
-      end
-  end
-  return false
+    end
+    return false
 end
 
 function module.ifAuthorized(requestHandler, allowedToken, fct)
-  -- check for the X-Authorization-Token header and compare its value to the ones present in allowedToken
-  if module.checkForToken(requestHandler, allowedToken) then
-    fct()
-  else
-    error(turbo.web.HTTPError(401, {message = "Unauthorized."}))
-  end
+    -- check for the X-Authorization-Token header and compare its value to the ones present in allowedToken
+    if module.checkForToken(requestHandler, allowedToken) then
+        fct()
+    else
+        error(turbo.web.HTTPError(401, { message = "Unauthorized." }))
+    end
 end
 
-function module.checkFilterAttributes (filterObject)
-  local requiredKeys = filterObject['id'] ~= nil and filterObject['filter'] ~= nil
-  -- pipes present => it should be an array of numbers (logical consequence)
-  local pipesCorrect = not (filterObject['pipes'] ~= nil) or (type(filterObject['pipes']) == 'table')
-  return requiredKeys and pipesCorrect
+function module.checkFilterAttributes(filterObject)
+    local requiredKeys = filterObject['id'] ~= nil and filterObject['filter'] ~= nil
+    requiredKeys = requiredKeys and (string.match(filterObject['id'], module.filterIdRegex) ~= nil)
+    -- pipes present => it should be an array of numbers (logical consequence)
+    local pipesCorrect = not (filterObject['pipes'] ~= nil) or (type(filterObject['pipes']) == 'table')
+    return requiredKeys and pipesCorrect
+end
+
+function module.prepareFilter(json, allowed_pipes)
+    local filter = {
+        id = tostring(json.id),
+        filter = json.filter,
+        timestamp = json.timestamp,
+        action = event.create,
+        pipes = {}
+    }
+
+    -- formatting of the pipes is already checked in apiUtils.checkFilterAttributes
+    if json['pipes'] ~= nil then
+        for i, pipe_number in ipairs(json['pipes']) do
+            if (allowed_pipes[pipe_number] ~= nil) then
+                filter.pipes[i] = pipe_number
+            else
+                error(turbo.web.HTTPError(400, { error = "Pipe number " .. tostring(pipe_number) .. " not allowed." }))
+            end
+        end
+    else
+        filter.pipes = allowed_pipes
+    end
+    return filter
+end
+
+function module.applyFilter(filter, filters, pipes)
+    if filters[filter.id] ~= nil then
+        error(turbo.web.HTTPError(400, { error = "Filter id is already in use. Choose another one." }))
+    else
+        filters[filter.id] = filter
+        -- add filter to pipe (what if pipe argument is not present? => add to all)
+        for i, pipe in ipairs(pipes) do
+            if filter.pipes[i] ~= nil then
+                pipe:send(event.newEvent(filter.filter, event.create, filter.id, filter.timestamp))
+            end
+        end
+    end
 end
 
 return module

--- a/restApi.lua
+++ b/restApi.lua
@@ -161,7 +161,7 @@ function mod.start(turbo, args, pipes)
             end
 
             if #filter_not_found ~= 0 then
-                return error(turbo.web.HTTPError(400, { error = "Filter not found", not_found_ids = filter_not_found, removed_filter = removed_filter }))
+                return error(turbo.web.HTTPError(404, { error = "Filter not found", not_found_ids = filter_not_found, removed_filter = removed_filter }))
             end
 
             self:write(removed_filter)

--- a/restApi.lua
+++ b/restApi.lua
@@ -6,120 +6,119 @@ local mod = {}
 -- args need to contain: args.apiToken and api.dumperThreads and we need access to the pipes
 -- to interface the dumperThreads and apply new filters
 function mod.start(turbo, args, pipes)
-  -- this webhandler modifies specific filter (i.e given by an id)
-  local SpecificFilterWebHandler = class("SpecificFilterWebHandler", turbo.web.RequestHandler)
-  -- this Webhandler handles only creation of a filter and showing all (under the namespace /filter/)
-  local FilterWebHandler = class("FilterWebHandler", turbo.web.RequestHandler)
+    -- this webhandler modifies specific filter (i.e given by an id)
+    local SpecificFilterWebHandler = class("SpecificFilterWebHandler", turbo.web.RequestHandler)
+    -- this Webhandler handles only creation of a filter and showing all (under the namespace /filter/)
+    local FilterWebHandler = class("FilterWebHandler", turbo.web.RequestHandler)
 
-  -- RegExes to check on the filter ids/paths
-  local FILTER_ID_REGEX = "([a-zA-Z0-9]+)"
-  local SPECIFIC_FILTER_REGEX = string.format("^/filter/%s$", FILTER_ID_REGEX)
+    -- RegExes to check on the filter ids/paths
+    local SPECIFIC_FILTER_REGEX = string.format("^/filter/%s$", apiUtils.filterIdRegex)
 
-  local filters = { }
-
-  function SpecificFilterWebHandler:get()
-    local function showFilter()
-      local filterId = string.match(self.request.path, SPECIFIC_FILTER_REGEX)
-      if filters[filterId] ~= nil then
-        self:write(filters[filterId])
-        self:finish()
-      else
-        error(turbo.web.HTTPError(404, {error = "Not found"}))
-      end
+    -- create the array of pipes where we want to apply the filter
+    local ALLOWED_PIPES = {}
+    for i = 1, args.dumperThreads do
+        ALLOWED_PIPES[i] = i
     end
-    apiUtils.ifAuthorized(self, args.apiToken, showFilter)
-  end
 
-  function SpecificFilterWebHandler:put()
-    error(turbo.web.HTTPError(501, {error = "Update not implemented."}))
-  end
+    local filters = {}
 
-  function SpecificFilterWebHandler:delete()
-    local function deleteFilter()
-      local filterId = string.match(self.request.path, SPECIFIC_FILTER_REGEX)
-      if filters[filterId] ~= nil then
-        local filter = filters[filterId]
-        filters[filterId] = nil
-        filter.action = event.delete
-        -- Remove filter from flowscope
-        for i,_ in ipairs(filter.pipes) do
-          pipes[i]:send(event.newEvent(filter.filter, event.delete, filter.id, filter.timestamp))
+    function SpecificFilterWebHandler:get()
+        local function showFilter()
+            local filterId = string.match(self.request.path, SPECIFIC_FILTER_REGEX)
+            if filters[filterId] ~= nil then
+                self:write(filters[filterId])
+                self:finish()
+            else
+                error(turbo.web.HTTPError(404, { error = "Not found" }))
+            end
         end
-        self:write(filter)
-        self:finish()
-      else
-        error(turbo.web.HTTPError(404, {error = "Not found."}))
-      end
+
+        apiUtils.ifAuthorized(self, args.apiToken, showFilter)
     end
-    apiUtils.ifAuthorized(self, args.apiToken, deleteFilter)
-  end
 
-  function FilterWebHandler:post()
-    local function createFilter()
-      -- this will raise an error if json is not present
-      local jsonBody = self:get_json(true)
-      -- create the array of pipes where we want to apply the filter
-      local insertToPipes = {}
+    function SpecificFilterWebHandler:put()
+        error(turbo.web.HTTPError(501, { error = "Update not implemented." }))
+    end
 
-      if jsonBody == nil or not apiUtils.checkFilterAttributes(jsonBody) then
-        error(turbo.web.HTTPError(400, {error = "Filter json malformed."}))
-      end
-      --  Test the filter id
-
-
-      for i = 1, args.dumperThreads do
-        insertToPipes[i] = i
-      end
-      local filter = {
-        id = tostring(jsonBody.id),
-        filter = jsonBody.filter,
-        timestamp = jsonBody.timestamp,
-        action = event.create,
-        pipes = {}
-      }
-      -- formatting of the pipes is already checked in apiUtils.checkFilterAttributes
-      if jsonBody['pipes'] ~= nil then
-        for i,pipe_number in ipairs(jsonBody['pipes']) do
-          if(insertToPipes[pipe_number] ~= nil) then
-            filter.pipes[i] = pipe_number
-          else
-            error(turbo.web.HTTPError(400, {error = "Pipe number " .. tostring(pipe_number) .. " not allowed."}))
-          end
+    function SpecificFilterWebHandler:delete()
+        local function deleteFilter()
+            local filterId = string.match(self.request.path, SPECIFIC_FILTER_REGEX)
+            if filters[filterId] ~= nil then
+                local filter = filters[filterId]
+                filters[filterId] = nil
+                filter.action = event.delete
+                -- Remove filter from flowscope
+                for i, _ in ipairs(filter.pipes) do
+                    pipes[i]:send(event.newEvent(filter.filter, event.delete, filter.id, filter.timestamp))
+                end
+                self:write(filter)
+                self:finish()
+            else
+                error(turbo.web.HTTPError(404, { error = "Not found." }))
+            end
         end
-      else
-        filter.pipes = insertToPipes
-      end
 
-      if filters[filter.id] ~= nil then
-        error(turbo.web.HTTPError(400, {error = "Filter id is already in use. Choose another one."}))
-      else
-        filters[filter.id] = filter
-        -- add filter to pipe (what if pipe argument is not present? => add to all)
-        for i, pipe in ipairs(pipes) do
-          if insertToPipes[i] ~= nil then
-            pipe:send(event.newEvent(filter.filter, event.create, filter.id, filter.timestamp))
-          end
+        apiUtils.ifAuthorized(self, args.apiToken, deleteFilter)
+    end
+
+    function FilterWebHandler:post()
+        local function createFilter()
+            -- this will raise an error if json is not present
+            local jsonBody = self:get_json(true)
+
+            -- decide if we have an array of filters or only one filter
+            -- specific to one filter are the keys 'filter' and 'id' - but should not have more than 'filter', 'id',
+            -- 'timestamp' and 'pipes' - else we are ignoring them
+            -- whereas the array does not have any of these
+            if jsonBody == nil then
+                return error(turbo.web.HTTPError(400, { error = "Filter json malformed." }))
+            end
+
+            local singleFilter = jsonBody['filter'] ~= nil and jsonBody['id'] ~= nil
+            print("Single filter: " .. tostring(singleFilter))
+            if singleFilter then
+                if apiUtils.checkFilterAttributes(jsonBody) then
+                    local filter = apiUtils.prepareFilter(jsonBody, ALLOWED_PIPES)
+                    apiUtils.applyFilter(filter, filters, pipes)
+                    self:write(filter)
+                    self:finish()
+                    return
+                else
+                    return error(turbo.web.HTTPError(400, { error = "Filter json malformed." }))
+                end
+            end
+
+            -- know we handle the pipelined filter application
+            local appliedFilter = {}
+            for i, jsonFilter in ipairs(jsonBody) do
+                if apiUtils.checkFilterAttributes(jsonFilter) then
+                    local filter = apiUtils.prepareFilter(jsonFilter, ALLOWED_PIPES)
+                    apiUtils.applyFilter(filter, filters, pipes)
+                    appliedFilter[#appliedFilter + 1] = filter
+                else
+                    return error(turbo.web.HTTPError(400, { error = "Filter json malformed." }))
+                end
+            end
+            self:write(appliedFilter)
+            self:finish()
         end
-        self:write(filter)
-        self:finish()
-      end
+
+        apiUtils.ifAuthorized(self, args.apiToken, createFilter)
     end
 
-    apiUtils.ifAuthorized(self, args.apiToken, createFilter)
-  end
+    function FilterWebHandler:get()
+        local function showFilters()
+            self:write(filters)
+            self:finish()
+        end
 
-  function FilterWebHandler:get()
-    local function showFilters()
-      self:write(filters)
-      self:finish()
+        apiUtils.ifAuthorized(self, args.apiToken, showFilters)
     end
-    apiUtils.ifAuthorized(self, args.apiToken, showFilters)
-  end
 
-  return {
-    { SPECIFIC_FILTER_REGEX, SpecificFilterWebHandler},
-    { "^/filter/$", FilterWebHandler}
-  }
+    return {
+        { SPECIFIC_FILTER_REGEX, SpecificFilterWebHandler },
+        { "^/filter/$", FilterWebHandler }
+    }
 end
 
 return mod


### PR DESCRIPTION
Hi Max,

For performance improvements of the http api, I need the ability to perform the add and delete operation for more than one filter with one http request. (i.e minimise the performance overhead).
For this purpose I created the 'pipelining' of these operation by changing the /filter/ api endpoint to allow these changes.

Regards,
Christian